### PR TITLE
Fix for parsing Accept headers with excess whitespace

### DIFF
--- a/fRequest.php
+++ b/fRequest.php
@@ -18,6 +18,7 @@
  * 
  * @version    1.0.0b20
  * @changes    1.0.0b20  Fixed problem where Accept headers are spaced out and mime-types won't match (mainly from IE) * @changes    1.0.0b19  Added the `$use_default_for_blank` parameter to ::get() [wb, 2011-06-03]
+ * @changes    1.0.0b19  Added the `$use_default_for_blank` parameter to ::get() [wb, 2011-06-03]
  * @changes    1.0.0b18  Backwards Compatibility Break - ::getBestAcceptType() and ::getBestAcceptLanguage() now return either `NULL`, `FALSE` or a string instead of `NULL` or a string, both methods are more robust in handling edge cases [wb, 2011-02-06]
  * @changes    1.0.0b17  Fixed support for 3+ dimensional input arrays, added a fixed for the PHP DoS float bug #53632, added support for type-casted arrays in ::get() [wb, 2011-01-09]
  * @changes    1.0.0b16  Backwards Compatibility Break - changed ::get() to remove binary characters when casting to a `string`, changed `int` and `integer` to cast to a real integer when possible, added new types of `binary` and `integer!` [wb, 2010-11-30]


### PR DESCRIPTION
This problem is mainly caused by some crazy accept header that's
sent 50% of the time in IE, but it may be caused by other
browsers that add additional whitespace.  Not sure if the standard
is clear on whether extra whitespace can or can't exist, but
either way this solves it for non-compliant browsers.
