### PR TITLE
fixed a typo on strtolower in fSchema

### DIFF
--- a/fSchema.php
+++ b/fSchema.php
@@ -3024,7 +3024,7 @@ class fSchema
 	 */
 	public function setColumnInfoOverride($column_info, $table, $column=NULL)
 	{
-		$table = strotlower($table);
+		$table = strtolower($table);
 		if ($column !== NULL) {
 			$column = strtolower($column);
 		}


### PR DESCRIPTION
There was a typo to strtoupper in fSchema. I updated strotupper to strtoupper.