### PR TITLE
Fix to self::iconv to strip illegal characters

### DIFF
--- a/fResult.php
+++ b/fResult.php
@@ -55,6 +55,8 @@ class fResult implements Iterator
 	 */
 	static private function iconv($in_charset, $out_charset, $string)
 	{
+		mb_substitute_character("none");
+		$string = mb_convert_encoding($string, $out_charset, $in_charset);
 		return iconv($in_charset, $out_charset, $string);
 	}
 


### PR DESCRIPTION
 Running strings through mb_convert_encoding as well as iconv for self::iconv method to strip illegal characters and avoid the iconv illegal character notice in php 5.3