### PR TITLE
Updated fetchMySQLKeys() to tolerate backticks

### DIFF
--- a/fSchema.php
+++ b/fSchema.php
@@ -1181,19 +1181,19 @@ class fSchema
 			$row    = $result->fetchRow();
 
 			// Primary keys
-			preg_match_all('/PRIMARY KEY\s+\("(.*?)"\),?\n/U', $row['Create Table'], $matches, PREG_SET_ORDER);
+			preg_match_all('/PRIMARY KEY\s+\(["`](.*?)["`]\),?\n/U', $row['Create Table'], $matches, PREG_SET_ORDER);
 			if (!empty($matches)) {
 				$keys[$table]['primary'] = explode('","', strtolower($matches[0][1]));
 			}
 
 			// Unique keys
-			preg_match_all('/UNIQUE KEY\s+"([^"]+)"\s+\("(.*?)"\),?\n/U', $row['Create Table'], $matches, PREG_SET_ORDER);
+			preg_match_all('/UNIQUE KEY\s+["`]([^"`]+)["`]\s+\(["`](.*?)["`]\).*,?\n/U', $row['Create Table'], $matches, PREG_SET_ORDER);
 			foreach ($matches as $match) {
 				$keys[$table]['unique'][] = explode('","', strtolower($match[2]));
 			}
 
 			// Foreign keys
-			preg_match_all('#FOREIGN KEY \("([^"]+)"\) REFERENCES "([^"]+)" \("([^"]+)"\)(?:\sON\sDELETE\s(SET\sNULL|SET\sDEFAULT|CASCADE|NO\sACTION|RESTRICT))?(?:\sON\sUPDATE\s(SET\sNULL|SET\sDEFAULT|CASCADE|NO\sACTION|RESTRICT))?#', $row['Create Table'], $matches, PREG_SET_ORDER);
+			preg_match_all('#FOREIGN KEY \(["`]([^"`]+)["`]\) REFERENCES ["`]([^"`]+)["`] \(["`]([^"`]+)["`]\)(?:\sON\sDELETE\s(SET\sNULL|SET\sDEFAULT|CASCADE|NO\sACTION|RESTRICT))?(?:\sON\sUPDATE\s(SET\sNULL|SET\sDEFAULT|CASCADE|NO\sACTION|RESTRICT))?#', $row['Create Table'], $matches, PREG_SET_ORDER);
 			foreach ($matches as $match) {
 				$temp = array(
 					'column'         => strtolower($match[1]),


### PR DESCRIPTION
The MySQL 'SHOW CREATE TABLE' output can include backticks to escape the column names. The regular expression patterns in fetchMySQLKeys() were loosened to tolerate backticks in addition to double quotes. Also the UNIQUE KEYS pattern was loosened to tolerate additional statements such as 'USING BTREE' which my occur before the end of the line.